### PR TITLE
Fix shebang on `start_vsftpd.sh`

### DIFF
--- a/start_vsftpd.sh
+++ b/start_vsftpd.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 #Remove all ftp users
 grep '/ftp/' /etc/passwd | cut -d':' -f1 | xargs -n1 deluser


### PR DESCRIPTION
The shebang on the `start_vsftpd.sh` is wrong (missing `!`), and it was giving me trouble when trying to start it with supervisor. 