### PR TITLE
Update Alpine from 3.10 to 3.13.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.13
 RUN apk --no-cache add vsftpd
 
 COPY start_vsftpd.sh /bin/start_vsftpd.sh


### PR DESCRIPTION
Updates the alpine version from 3.10 to 3.13.

This also solves my problem that the container exits after some time with error 139.