### PR TITLE
Automated multi-arch build via github actions

### DIFF
--- a/.github/workflows/docker-publish-image.yml
+++ b/.github/workflows/docker-publish-image.yml
@@ -1,0 +1,86 @@
+name: Docker hub auto publish image
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      # Run when file is edited
+      - Dockerfile
+      - start_vsftpd.sh
+      - vsftpd.conf
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  # Image name at docker hub
+  IMAGE_NAME: delfer/alpine-ftp-server
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v2
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+       
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          # Genrate secret from here https://hub.docker.com/settings/security
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Add Label Schema to Dockerfile
+        run: |
+          # Label Schema based on http://label-schema.org/rc1/
+          TIME_ISO=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "LABEL org.label-schema.build-date=$TIME_ISO" >> Dockerfile
+          echo "LABEL org.label-schema.name=vsftpd" >> Dockerfile
+          echo "LABEL org.label-schema.url=https://security.appspot.com/vsftpd.html" >> Dockerfile
+          echo "LABEL org.label-schema.vcs-url=https://github.com/delfer/docker-alpine-ftp-server" >> Dockerfile
+          GIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
+          echo "LABEL org.label-schema.vcs-ref=$GIT_HASH" >> Dockerfile
+          echo "LABEL org.label-schema.schema-version=1.0.0-rc.1" >> Dockerfile
+          echo "LABEL org.label-schema.docker.cmd=\"docker run -d -p 21:21 -e USERS=\"username|password\" delfer/alpine-ftp-server\"" >> Dockerfile
+          # Show edited Dockerfile content
+          cat Dockerfile
+                    
+      - name: Build and push latest
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
I needed your image for my raspberry pi 3. So I merged in some code from another repo of mine.

This will auto generate images  when relevant files are edited. You will however have to disable docker hub automated builds and accept github actions now builds you images to get it working.

Also you need to generate a github secrets from here https://hub.docker.com/settings/security to allow github to publish images on your behalf on docker hub. 

This also adds [Label Schema ](http://label-schema.org/rc1/) to the image.

Related to #10.