### PR TITLE
add default chroot security

### DIFF
--- a/vsftpd.conf
+++ b/vsftpd.conf
@@ -68,7 +68,8 @@ ftpd_banner=Welcome Alpine ftp server https://hub.docker.com/r/delfer/alpine-ftp
 # (Warning! chroot'ing can be very dangerous. If using chroot, make sure that
 # the user does not have write access to the top level directory within the
 # chroot)
-#chroot_local_user=YES
+chroot_local_user=YES
+allow_writeable_chroot=YES
 #chroot_list_enable=YES
 # (default follows)
 #chroot_list_file=/etc/vsftpd.chroot_list

--- a/vsftpd.conf
+++ b/vsftpd.conf
@@ -68,6 +68,10 @@ ftpd_banner=Welcome Alpine ftp server https://hub.docker.com/r/delfer/alpine-ftp
 # (Warning! chroot'ing can be very dangerous. If using chroot, make sure that
 # the user does not have write access to the top level directory within the
 # chroot)
+#
+# a combination of chroot_local_user=YES and allow_writeable_chroot=YES will
+# setup default security, so users cannot escape their home directory
+#
 chroot_local_user=YES
 allow_writeable_chroot=YES
 #chroot_list_enable=YES

--- a/vsftpd.conf
+++ b/vsftpd.conf
@@ -74,6 +74,7 @@ ftpd_banner=Welcome Alpine ftp server https://hub.docker.com/r/delfer/alpine-ftp
 #
 chroot_local_user=YES
 allow_writeable_chroot=YES
+
 #chroot_list_enable=YES
 # (default follows)
 #chroot_list_file=/etc/vsftpd.chroot_list


### PR DESCRIPTION
I believe this should be the default setup for vsftpd

chroot_local_user=YES
allow_writeable_chroot=YES (this option is not in the .conf file by default, and its default is "NO")

This will inhibit users to escape their home directory.
Of course, there are several ways to setup vsftpd, but this would be the most secure starting point, imho.