### PR TITLE
Fix container stop on disconnect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,22 @@
-FROM alpine:3.15
-RUN apk --no-cache add vsftpd
+ARG BASE_IMG=alpine:3.15
+
+FROM $BASE_IMG AS pidproxy
+
+RUN apk --no-cache add alpine-sdk upx \
+ && git clone https://github.com/ZentriaMC/pidproxy.git \
+ && cd pidproxy \
+ && git checkout 193e5080e3e9b733a59e25d8f7ec84aee374b9bb \
+ && make pidproxy.upx \
+ && mv pidproxy.upx /usr/bin/pidproxy \
+ && cd .. \
+ && rm -rf pidproxy \
+ && apk del alpine-sdk upx
+
+
+FROM $BASE_IMG
+
+COPY --from=pidproxy /usr/bin/pidproxy /usr/bin/pidproxy
+RUN apk --no-cache add vsftpd tini
 
 COPY start_vsftpd.sh /bin/start_vsftpd.sh
 COPY vsftpd.conf /etc/vsftpd/vsftpd.conf
@@ -7,6 +24,4 @@ COPY vsftpd.conf /etc/vsftpd/vsftpd.conf
 EXPOSE 21 21000-21010
 VOLUME /ftp/ftp
 
-STOPSIGNAL SIGKILL
-
-ENTRYPOINT ["/bin/start_vsftpd.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/start_vsftpd.sh"]

--- a/start_vsftpd.sh
+++ b/start_vsftpd.sh
@@ -55,6 +55,9 @@ fi
 if [ ! -z "$1" ]; then
   exec "$@"
 else
-  exec /usr/sbin/vsftpd -opasv_min_port=$MIN_PORT -opasv_max_port=$MAX_PORT $ADDR_OPT /etc/vsftpd/vsftpd.conf
+  vsftpd -opasv_min_port=$MIN_PORT -opasv_max_port=$MAX_PORT $ADDR_OPT /etc/vsftpd/vsftpd.conf
+  [ -d /var/run/vsftpd ] || mkdir /var/run/vsftpd
+  pgrep vsftpd | tail -n 1 > /var/run/vsftpd/vsftpd.pid
+  exec pidproxy /var/run/vsftpd/vsftpd.pid true
 fi
 

--- a/vsftpd.conf
+++ b/vsftpd.conf
@@ -91,5 +91,5 @@ pasv_addr_resolve=YES
 ## Disable seccomp filter sanboxing
 seccomp_sandbox=NO
 # Run in background
-background=NO
+background=YES
 


### PR DESCRIPTION
Fixing https://github.com/delfer/docker-alpine-ftp-server/issues/15

Vsftpd moved to backgroud. Added https://github.com/ZentriaMC/pidproxy to monitor main vsftpd process and https://github.com/krallin/tini supervisor to reap zombies and performing signal forwarding.

Starting process list:
```
PID   USER     TIME  COMMAND
    1 root      0:00 /sbin/tini -- /bin/start_vsftpd.sh
    7 root      0:00 pidproxy /var/run/vsftpd/vsftpd.pid true
   30 root      0:00 vsftpd -opasv_min_port=21000 -opasv_max_port=21010 -opasv_
   34 root      0:00 ps -a
```

Tested:

- logs - in STDOUT **OK**
- `docker kill` - container stopped **OK**
- `docker restart` - container restarted **OK**
- docker exec -ti alpine-ftp killall tini - container stopped **OK**