### PR TITLE
Add group support and timezone support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ FROM $BASE_IMG
 COPY --from=pidproxy /usr/bin/pidproxy /usr/bin/pidproxy
 RUN apk --no-cache add vsftpd tini
 
+# Add timezone support and default to UTC
+RUN apk --no-cache add alpine-conf && \
+    setup-timezone -z UTC
+
 COPY start_vsftpd.sh /bin/start_vsftpd.sh
 COPY vsftpd.conf /etc/vsftpd/vsftpd.conf
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ docker run -d \
     -p 21:21 \
     -p 21000-21010:21000-21010 \
     -e USERS="one|1234" \
+    -e TZ="America/New_York" \
     -e ADDRESS=ftp.site.domain \
     delfer/alpine-ftp-server
 ```
@@ -20,6 +21,7 @@ Environment variables:
 - `ADDRESS` - external address witch clients can connect passive ports (optional, should resolve to ftp server ip address)
 - `MIN_PORT` - minimum port number to be used for passive connections (optional, default `21000`)
 - `MAX_PORT` - maximum port number to be used for passive connections (optional, default `21010`)
+- `TZ` - set the running container to a specific timezone instead of default UTC (optional)
 
 ## USERS examples
 

--- a/start_vsftpd.sh
+++ b/start_vsftpd.sh
@@ -72,6 +72,10 @@ if [ ! -z "$TLS_CERT" ] || [ ! -z "$TLS_KEY" ]; then
   TLS_OPT="-orsa_cert_file=$TLS_CERT -orsa_private_key_file=$TLS_KEY -ossl_enable=YES -oallow_anon_ssl=NO -oforce_local_data_ssl=YES -oforce_local_logins_ssl=YES -ossl_tlsv1=YES -ossl_sslv2=NO -ossl_sslv3=NO -ossl_ciphers=HIGH"
 fi
 
+if [ ! -z "$TZ" ]; then
+  setup-timezone -z $TZ
+fi
+
 # Used to run custom commands inside container
 if [ ! -z "$1" ]; then
   exec "$@"


### PR DESCRIPTION
Hi,

I needed to specify a gid for the created user and the correct timezone inside the running container.

For the group part it's working and I didn't think of a better solution.
For the TZ, I'm less sure. I found some information about a `ENV TZ` support in the Dockerfile but wasn't able to confirm so I go with the inside's alpine route and it's working. (official alpine doc : https://wiki.alpinelinux.org/wiki/Alpine_setup_scripts#setup-timezone)

Thanks a lot for your work.