### PR TITLE
Add group support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker run -d \
 
 Environment variables:
 - `USERS` - space and `|` separated list (optional, default: `alpineftp|alpineftp`)
-  - format `name1|password1|[folder1][|uid1] name2|password2|[folder2][|uid2]`
+  - format `name1|password1|[folder1][|uid1][|gid1] name2|password2|[folder2][|uid2][|gid2]`
 - `ADDRESS` - external address witch clients can connect passive ports (optional, should resolve to ftp server ip address)
 - `MIN_PORT` - minimum port number to be used for passive connections (optional, default `21000`)
 - `MAX_PORT` - maximum port number to be used for passive connections (optional, default `21010`)
@@ -25,7 +25,9 @@ Environment variables:
 
 - `user|password foo|bar|/home/foo`
 - `user|password|/home/user/dir|10000`
+- `user|password|/home/user/dir|10000|10000`
 - `user|password||10000`
+- `user|password||10000|82` : add to an existing group (www-data)
 
 ## FTPS (File Transfer Protocol + SSL) Example
 

--- a/start_vsftpd.sh
+++ b/start_vsftpd.sh
@@ -4,13 +4,15 @@
 grep '/ftp/' /etc/passwd | cut -d':' -f1 | xargs -r -n1 deluser
 
 #Create users
-#USERS='name1|password1|[folder1][|uid1] name2|password2|[folder2][|uid2]'
+#USERS='name1|password1|[folder1][|uid1][|gid1] name2|password2|[folder2][|uid2][|gid2]'
 #may be:
 # user|password foo|bar|/home/foo
 #OR
 # user|password|/home/user/dir|10000
 #OR
-# user|password||10000
+# user|password|/home/user/dir|10000|10000
+#OR
+# user|password||10000|82
 
 #Default user 'ftp' with password 'alpineftp'
 
@@ -24,6 +26,8 @@ for i in $USERS ; do
   PASS=$(echo $i | cut -d'|' -f2)
   FOLDER=$(echo $i | cut -d'|' -f3)
   UID=$(echo $i | cut -d'|' -f4)
+  # Add group handling
+  GID=$(echo $i | cut -d'|' -f5)
 
   if [ -z "$FOLDER" ]; then
     FOLDER="/ftp/$NAME"
@@ -31,17 +35,24 @@ for i in $USERS ; do
 
   if [ ! -z "$UID" ]; then
     UID_OPT="-u $UID"
+    if [ -z "$GID" ]; then
+      GID=$UID
+    fi
     #Check if the group with the same ID already exists
-    GROUP=$(getent group $UID | cut -d: -f1)
+    GROUP=$(getent group $GID | cut -d: -f1)
     if [ ! -z "$GROUP" ]; then
       GROUP_OPT="-G $GROUP"
+    elif [ ! -z "$GID" ]; then
+      # Group don't exist but GID supplied
+      addgroup -g $GID $NAME
+      GROUP_OPT="-G $NAME"
     fi
   fi
 
   echo -e "$PASS\n$PASS" | adduser -h $FOLDER -s /sbin/nologin $UID_OPT $GROUP_OPT $NAME
   mkdir -p $FOLDER
   chown $NAME:$GROUP $FOLDER
-  unset NAME PASS FOLDER UID
+  unset NAME PASS FOLDER UID GID
 done
 
 


### PR DESCRIPTION
Allow to specify a gid for the users.
Group will be reuse if existing or a new group with given id (and user name) will be created if not.