### PR TITLE
Create private user folders, preventing other users from reading user folder contents.

### DIFF
--- a/start_vsftpd.sh
+++ b/start_vsftpd.sh
@@ -50,7 +50,7 @@ for i in $USERS ; do
   fi
 
   echo -e "$PASS\n$PASS" | adduser -h $FOLDER -s /sbin/nologin $UID_OPT $GROUP_OPT $NAME
-  mkdir -p $FOLDER
+  mkdir -m 750 -p $FOLDER
   chown $NAME:$GROUP $FOLDER
   unset NAME PASS FOLDER UID GID
 done


### PR DESCRIPTION
### Proposal

Make user folders private. This prevents other FTP users and groups from reading the contents of each user's FTP folder.

### Note about Parent Directories

This does not prevent an FTP user from going up a directory however, so only partially helps [the issue](https://github.com/delfer/docker-alpine-ftp-server/issues/19) that FTP users can go up to the parent directory and view the names of other user folders.

By removing the read permission bit from all users on the parent directory, FTP users can be prevented from seeing the contents of the parent directory. For example.

If we have two user folders:
```sh
$ ls -al /ftp
total 0
drwxr-x--x 1 root   root   34 Mar 31 09:45 .
drwxr-xr-x 1 root   root    6 Mar 30 06:43 ..
drwxr-s--- 1 user1  user1  16 Mar 31 09:50 user1
drwxr-s--- 1 user2  user2   0 Mar 31 09:45 user2
```
Note the `r` bit is missing from `/ftp`. This is applied with:

```sh
$ chmod o-r /ftp
```

It is a bit tricky to add this to the `start_vsftpd.sh` script, as user folders aren't necessarily saved in the same parent directory, as completely separate directories can be configured in the `USERS` environment variable when starting the container. Therefore, I suggest that is left as an exercise for the user, should they want to keep the names of other users and their folders private.